### PR TITLE
Add UX improvements to the level editor

### DIFF
--- a/Bemol/App.swift
+++ b/Bemol/App.swift
@@ -227,7 +227,6 @@ extension App {
     main.state = state.mainScreenState
     levelEditor.state = state.levelEditorScreenState
     accuracy.state = state.accuracyScreenState
-    levelEditorView.isHidden = !state.isLevelEditorVisible
     mainView.isHidden = state.isLevelEditorVisible || state.isAccuracyScreenVisible || state.hasError
     errorView.isHidden = !state.hasError
     errorScreen.error = state.error
@@ -237,6 +236,12 @@ extension App {
       accuracy.state = state.accuracyScreenState
     }
 
+    if state.isLevelEditorVisible {
+      levelEditor.state = nil // Force a state update.
+      levelEditor.state = state.levelEditorScreenState
+    }
+
     accuracyView.isHidden = !state.isAccuracyScreenVisible
+    levelEditorView.isHidden = !state.isLevelEditorVisible
   }
 }

--- a/Bemol/AppLoop.swift
+++ b/Bemol/AppLoop.swift
@@ -268,6 +268,10 @@ final class AppLoop {
             return level
           }
 
+          if let baseLevel = currentState.baseLevel, notes == baseLevel.notes {
+            return baseLevel
+          }
+
           return try await self.environment
             .practiceManager
             .useTemporaryLevel(level: level.withNotes(notes))
@@ -288,6 +292,10 @@ final class AppLoop {
       nextState.answer = nil
       nextState.highlightedNote = nil
       nextState.isInteractionEnabled = true
+
+      if !level.isCustom {
+        nextState.baseLevel = level
+      }
 
       if !environment.preferences.value(for: .userHasSeenOnboardingPrefKey) {
         nextState.loadNextTip()

--- a/Bemol/AppState.swift
+++ b/Bemol/AppState.swift
@@ -23,6 +23,7 @@ struct AppState {
   var isLoading: Bool = false
   var isPracticing: Bool = false
   var level: Level? = nil
+  var baseLevel: Level? = nil
   var session: Session? = nil
   var question: Question? = nil
   var answer: Note? = nil
@@ -75,6 +76,7 @@ extension AppState {
   var levelEditorScreenState: LevelEditorScreenState {
     LevelEditorScreenState(
       key: level?.key ?? .c,
+      allNotes: baseLevel?.notes ?? [],
       selectedNotes: level?.notes ?? []
     )
   }

--- a/Bemol/Models/Practice/Level.swift
+++ b/Bemol/Models/Practice/Level.swift
@@ -137,6 +137,7 @@ extension Level {
       cadence: cadence,
       spansMultipleOctaves: spansMultipleOctaves,
       range: range,
+      isCustom: isCustom,
       sessions: sessions
     )
   }

--- a/Bemol/Screens/LevelEditorScreen.swift
+++ b/Bemol/Screens/LevelEditorScreen.swift
@@ -26,6 +26,7 @@ struct LevelEditorScreenDelegate {
 
 struct LevelEditorScreenState {
   var key: NoteName = .c
+  var allNotes: [Note]
   var selectedNotes: [Note]
 }
 
@@ -72,12 +73,11 @@ final class LevelEditorScreen {
       if oldValue == nil || key != oldKey || notes != oldNotes {
         keyboardView.scrollTo(note: Note(name: state?.key ?? .c, octave: 1))
         keyboardView.setLabelForAllNotes(nil)
+        keyboardView.setEnabledForAllKeys(false)
 
-        for octave in range {
-          keyboardView.setLabels(
-            NoteName.all.map(\.letter),
-            for: NoteName.all.map { Note(name: $0, octave: octave ) }
-          )
+        for note in state?.allNotes ?? [] {
+          keyboardView.setLabel(note.name.letter, for: note)
+          keyboardView.setEnabled(true, for: [note])
         }
 
         setNotes(notes)


### PR DESCRIPTION
- Restrict the level editor's note range to the range of the level being edited.
- Fix a bug where a level's notes were not automatically selected in the level editor.
- Fix a bug where the title view didn't show `*` next to a custom level name after a session stops.